### PR TITLE
Fix struct tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: sudo apt-get install rubygems
       - run:
           name: Install cddl gem
-          command: gem install cddl -v 0.8.5
+          command: sudo gem install cddl -v 0.8.5
       - run:
           name: "Verify binary format"
           command: make format-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: make test
   unit-test-go:
       docker:
-        - image: circleci/golang:1.13
+        - image: circleci/golang:1.15
       steps:
         - checkout
         - run:
@@ -22,6 +22,17 @@ jobs:
             command: make test
         - codecov/upload:
             file: ./single.coverprofile
+  format-test:
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run:
+          name: Install cddl gem
+          command: gem install cddl -v 0.8.5
+      - run:
+          name: "Verify binary format"
+          command: make format-test
 
 workflows:
   version: 2
@@ -29,3 +40,4 @@ workflows:
     jobs:
       - unit-test-go
       - unit-test-latest-go
+      - format-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install ruby
+          command: sudo apt-get install rubygems
+      - run:
           name: Install cddl gem
           command: gem install cddl -v 0.8.5
       - run:

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ LDFLAGS       	?= -w -s
 
 GO_TEST 				?= $(GO_BUILD_ENV_TEST_VARS) go test -ldflags "$(LDFLAGS)" -race -covermode=atomic -coverprofile=single.coverprofile
 
-.PHONY: test clean
+.PHONY: test clean format-test
 
 clean:
 	rm -f *.coverprofile
 
 test:
 	$(GO_TEST)
+
+format-test:
+	go test -v -tags cddltest -run TestValidGoCertificateFormat

--- a/certificates.go
+++ b/certificates.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"time"
 
-	//"github.com/ugorji/go/codec"
 	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/ed25519"
 )
@@ -34,16 +33,16 @@ func init() {
 
 // Certificate represents CBOR based certificates based on the provide spec.cddl
 type Certificate struct {
-	_ interface{} `codec:"-,toarray"`
+	_ struct{} `cbor:",toarray"`
 
-	SerialNumber uint64 `codec:"serial_number"`
-	Issuer       string `codec:"issuer"`
+	SerialNumber uint64 `cbor:"serial_number"`
+	Issuer       string `cbor:"issuer"`
 	// NotBefore and NotAfter might be 0 to indicate to be ignored during validation
-	Validity   *Validity         `codec:"validity,omitempty"`
-	Subject    string            `codec:"subject"`
-	PubKey     ed25519.PublicKey `codec:"public_key"`
-	Extensions []Extension       `codec:"extensions"`
-	Signature  []byte            `codec:"signature"`
+	Validity   *Validity         `cbor:"validity,omitempty"`
+	Subject    string            `cbor:"subject"`
+	PubKey     ed25519.PublicKey `cbor:"public_key"`
+	Extensions []Extension       `cbor:"extensions"`
+	Signature  []byte            `cbor:"signature"`
 }
 
 // PublicKey returns the public key of this certificate as byte slice.
@@ -106,10 +105,10 @@ func (t Time) IsZero() bool {
 // Validity represents the time constrained validity of a Certificate.
 // NotBefore might be ZeroTime to ignore this constraint, same goes for NotAfter
 type Validity struct {
-	_struct interface{} `codec:"-,toarray"`
+	_ struct{} `cbor:",toarray"`
 
-	NotBefore Time `codec:"notBefore"`
-	NotAfter  Time `codec:"notAfter"`
+	NotBefore Time `cbor:"notBefore"`
+	NotAfter  Time `cbor:"notAfter"`
 }
 
 // Parse parses a Certificate from an io.Reader

--- a/extensions.go
+++ b/extensions.go
@@ -12,11 +12,11 @@ const (
 
 // Extension represents a Certificate Extension as specified for X.509 certificates
 type Extension struct {
-	_struct interface{} `codec:"-,toarray"`
+	_ struct{} `cbor:",toarray"`
 
-	OID      uint64 `codec:"oid"`
-	Critical bool   `codec:"critical"`
-	Value    []byte `codec:"value"`
+	OID      uint64 `cbor:"oid"`
+	Critical bool   `cbor:"critical"`
+	Value    []byte `cbor:"value"`
 }
 
 // KeyUsage limits for what the public key in a certificate can be used. Certain KeyUsages may be


### PR DESCRIPTION
This PR fixes the struct tags used by the new CBOR library. I forgot to switch to the new struct tags, when switching the CBOR library.
Additionally this PR adds a test step which verifies the binary format of the certificate against the cddl specification.